### PR TITLE
Fix of nullable operator in ShaderCache.hx

### DIFF
--- a/h3d/impl/ShaderCache.hx
+++ b/h3d/impl/ShaderCache.hx
@@ -11,7 +11,7 @@ class ShaderCache {
 
 	public function new( file : String, ?outputFile : String ) {
 		this.file = file;
-		this.outputFile = outputFile ?? file;
+		this.outputFile = outputFile == null ? file : outputFile;
 		sourceFile = file + ".source";
 	}
 


### PR DESCRIPTION
It fixes the error message `home/user/haxelib/heaps/2,0,0/h3d/impl/ShaderCache.hx:14: characters 33-34 : Unexpected ?` when following the heaps tutorial https://heaps.io/documentation/hello-world.html  when building. Apparently haxe does not have the `??` operator like in php